### PR TITLE
Removed redundant 'Content-Type:' string.

### DIFF
--- a/web/servlet/src/main/java/ai/api/web/AIWebhookServlet.java
+++ b/web/servlet/src/main/java/ai/api/web/AIWebhookServlet.java
@@ -41,7 +41,7 @@ import ai.api.model.Fulfillment;
  */
 public abstract class AIWebhookServlet extends HttpServlet {
 
-  private static final String RESPONSE_CONTENT_TYPE = "Content-Type: application/json";
+  private static final String RESPONSE_CONTENT_TYPE = "application/json";
 
   private static final String RESPONSE_CHARACTER_ENCODING = "utf-8";
 


### PR DESCRIPTION
Without this commit, the HTTP header in the response body will be as follows:

`Content-Type: Content-Type: application/json; charset=utf-8`