### PR TITLE
Added support for followupEvent to the Fulfilment class.

### DIFF
--- a/libai/pom.xml
+++ b/libai/pom.xml
@@ -11,7 +11,7 @@
 		<groupId>ai.api</groupId>
 		<artifactId>libai-base</artifactId>
 		<relativePath>..</relativePath>
-		<version>1.5.10</version>
+		<version>1.5.11</version>
 	</parent>
 	<build>
 		<finalName>libai</finalName>

--- a/libai/src/main/java/ai/api/model/Fulfillment.java
+++ b/libai/src/main/java/ai/api/model/Fulfillment.java
@@ -56,6 +56,9 @@ public class Fulfillment implements Serializable {
   @SerializedName("contextOut")
   private List<AIOutputContext> contextOut;
 
+  @SerializedName("followupEvent")
+  private AIEvent followupEvent;
+
   /** Get voice response to the request */
   public String getSpeech() {
     return speech;
@@ -152,5 +155,15 @@ public class Fulfillment implements Serializable {
   /** Set sequence of context objects set after intent completion. */
   public void setContextOut(final AIOutputContext... contextOut) {
     setContextOut(Arrays.asList(contextOut));
+  }
+
+  /** Get follow up event to be triggered*/
+  public AIEvent getFollowupEvent() {
+    return followupEvent;
+  }
+
+  /** Set follow up event to be triggered */
+  public void setFollowupEvent(AIEvent followupEvent) {
+    this.followupEvent = followupEvent;
   }
 }

--- a/libai/src/test/java/ai/api/model/FulfillmentTest.java
+++ b/libai/src/test/java/ai/api/model/FulfillmentTest.java
@@ -45,7 +45,8 @@ public class FulfillmentTest {
   private static final String TEST_FULFILLMENT_WEBHOOK_RESPONSE =
       "{\"speech\":\"text\"," + "\"displayText\":\"DisplayText\", \"source\":\"webhook\", "
           + "\"contextOut\": [{\"name\":\"weather\", \"lifespan\":2, \"parameters\":{\"city\":\"Rome\"}}],"
-          + "\"data\":{\"param\":\"value\"}}";
+          + "\"data\":{\"param\":\"value\"},"
+          + "\"followupEvent\":{\"data\":{\"event-param\":\"event-value\"},\"name\":\"test-event\"}}";
   
   private static final String TEST_FULFILLMENT_WITH_MESSAGES = "{\"speech\":\"test speech\","+
       "\"messages\":[{\"imageUrl\":\"url image\",\"type\":3},{\"title\":\"Quick title\","+
@@ -94,6 +95,11 @@ public class FulfillmentTest {
 
     assertEquals(1, fulfillment.getData().size());
     assertEquals("value", fulfillment.getData().get("param").getAsString());
+
+    assertNotNull(fulfillment.getFollowupEvent());
+    assertEquals("test-event", fulfillment.getFollowupEvent().getName());
+    assertEquals(1, fulfillment.getFollowupEvent().getData().size());
+    assertEquals("event-value", fulfillment.getFollowupEvent().getData().get("event-param"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ai.api</groupId>
     <artifactId>libai-base</artifactId>
-    <version>1.5.10</version>
+    <version>1.5.11</version>
     <packaging>pom</packaging>
 
     <name>Api.ai SDK</name>

--- a/speech/gcp/pom.xml
+++ b/speech/gcp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
     	<groupId>ai.api</groupId>
     	<artifactId>libai-base</artifactId>
-    	<version>1.5.10</version>
+    	<version>1.5.11</version>
     	<relativePath>../../pom.xml</relativePath>
     </parent>
     <properties>

--- a/web/servlet/pom.xml
+++ b/web/servlet/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>ai.api</groupId>
 		<artifactId>libai-base</artifactId>
-		<version>1.5.10</version>
+		<version>1.5.11</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>ai.api.libai.web</groupId>


### PR DESCRIPTION
API AI supports triggering intents via Events which can be returned from the webhook as described here:
https://api.ai/docs/fulfillment#section-format-of-response-from-the-service

The Fulfillment class was modified and a field containing AIEvent was added.